### PR TITLE
fix(#10): not cancelled animations on iOS

### DIFF
--- a/ios/AvoidSoftInput.swift
+++ b/ios/AvoidSoftInput.swift
@@ -8,6 +8,8 @@ class AvoidSoftInput: RCTEventEmitter {
     
     var isEnabled: Bool = false
     var isRootViewSlideUp: Bool = false
+    var isRootViewSlidingDown: Bool = false
+    var isRootViewSlidingUp: Bool = false
     var scrollContentInset: UIEdgeInsets = UIEdgeInsets.zero
     var scrollIndicatorInsets: UIEdgeInsets = UIEdgeInsets.zero
     var rootViewOriginY: CGFloat? = nil
@@ -39,20 +41,24 @@ class AvoidSoftInput: RCTEventEmitter {
             return
         }
         let keyboardFrame = keyboardSize.cgRectValue
-        
+
         if hasListeners {
             self.sendEvent(withName: SOFT_INPUT_SHOWN, body: [SOFT_INPUT_HEIGHT_KEY: keyboardFrame.height])
         }
-        
-        if isRootViewSlideUp || isEnabled == false {
+
+        if isRootViewSlideUp || isRootViewSlidingUp || isEnabled == false {
             return
         }
+
+        isRootViewSlidingUp = true
         
         guard let viewController = RCTPresentedViewController(), let focusedInput = findFirstResponder(view: viewController.view), let rootView = viewController.view else {
+            isRootViewSlidingUp = false
             return
         }
         
         if checkIfNestedInAvoidSoftInputView(view: focusedInput) {
+            isRootViewSlidingUp = false
             return
         }
         
@@ -62,11 +68,12 @@ class AvoidSoftInput: RCTEventEmitter {
         self.focusedInput = focusedInput
 
         guard let keyboardOffset = computeKeyboardOffset(keyboardHeight: keyboardFrame.height, firstResponder: focusedInput, containerView: rootView, rootView: rootView) else {
+            isRootViewSlidingUp = false
             return
         }
         
         self.bottomOffset = keyboardOffset + _avoidOffset
-        UIView.animate(withDuration: 0.66, delay: 0.3) {
+        UIView.animate(withDuration: 0.66, delay: 0.3, options: [.beginFromCurrentState]) {
             if let scrollView = findScrollViewForFirstResponder(view: focusedInput, rootView: rootView) {
                 let contentInsets = UIEdgeInsets.init(top: 0.0, left: 0.0, bottom: self.bottomOffset, right: 0.0)
                 self.scrollContentInset = scrollView.contentInset
@@ -79,28 +86,33 @@ class AvoidSoftInput: RCTEventEmitter {
                 }
             }
         } completion: { isCompleted in
+            self.isRootViewSlidingUp = false
             self.isRootViewSlideUp = true
         }
     }
     
-    @objc func keyboardWillHide(notification: NSNotification) {      
+    @objc func keyboardWillHide(notification: NSNotification) {
         if hasListeners {
             self.sendEvent(withName: SOFT_INPUT_HIDDEN, body: [SOFT_INPUT_HEIGHT_KEY: 0])
         }
-
-        if !isRootViewSlideUp || isEnabled == false {
+        
+        if (!isRootViewSlideUp && !isRootViewSlidingUp) || isRootViewSlidingDown || isEnabled == false {
             return
         }
+        
+        isRootViewSlidingDown = true
 
         guard let viewController = RCTPresentedViewController(), let focusedInput = focusedInput, let rootView = viewController.view else {
+            isRootViewSlidingDown = false
             return
         }
         
         if checkIfNestedInAvoidSoftInputView(view: focusedInput) {
+            isRootViewSlidingDown = false
             return
         }
-        
-        UIView.animate(withDuration: 0.22) {
+
+        UIView.animate(withDuration: 0.22, delay: 0, options: [.beginFromCurrentState]) {
             if let scrollView = findScrollViewForFirstResponder(view: focusedInput, rootView: rootView) {
                 scrollView.contentInset = self.scrollContentInset
                 scrollView.scrollIndicatorInsets = self.scrollIndicatorInsets
@@ -110,6 +122,7 @@ class AvoidSoftInput: RCTEventEmitter {
                 rootView.frame.origin.y += self.bottomOffset
             }
         } completion: { isCompleted in
+            self.isRootViewSlidingDown = false
             self.rootViewOriginY = nil
             self.focusedInput = nil
             self.isRootViewSlideUp = false


### PR DESCRIPTION
When soft input is quickly closed or opened, animations were not interrupted,
so it could end up with some blank area under content left, or content could have been cut

That commit resolves issue by adding .beginCurrentState option to UIView.animate method and
by adding some additional checks whether view is being translated up or down