### PR TITLE
fix(#37): incorrect keyboard height returned on nexus_s device

### DIFF
--- a/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputManager.kt
+++ b/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputManager.kt
@@ -3,7 +3,6 @@ package com.reactnativeavoidsoftinput
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.ValueAnimator
-import android.content.Context
 import android.os.Build
 import android.view.View
 import android.view.ViewTreeObserver
@@ -15,7 +14,7 @@ import com.facebook.react.uimanager.PixelUtil
 import kotlin.math.max
 import kotlin.math.min
 
-class AvoidSoftInputManager(private val context: Context) {
+class AvoidSoftInputManager(private val context: ReactContext) {
   private var mAnimationInterpolator = AvoidSoftInputInterpolator()
   private var mAvoidOffset: Float = 0F
   private var mAvoidSoftInputProvider: AvoidSoftInputProvider? = null
@@ -56,7 +55,7 @@ class AvoidSoftInputManager(private val context: Context) {
     setScrollListener(scrollView, mOnScrollListener)
     val currentFocusedViewLocation = IntArray(2)
     currentFocusedView.getLocationOnScreen(currentFocusedViewLocation)
-    val currentFocusedViewDistanceToBottom = DisplayMetricsHolder.getScreenDisplayMetrics().heightPixels - (currentFocusedViewLocation[1] + currentFocusedView.height) - getNavigationBarHeight(context)
+    val currentFocusedViewDistanceToBottom = DisplayMetricsHolder.getScreenDisplayMetrics().heightPixels - (currentFocusedViewLocation[1] + currentFocusedView.height) - (getRootViewBottomInset(context) ?: 0)
 
     val scrollToOffset = max(mCompleteSoftInputHeight - currentFocusedViewDistanceToBottom, 0)
 
@@ -200,7 +199,7 @@ class AvoidSoftInputManager(private val context: Context) {
   private fun applyOffsetToRootView(softInputHeight: Int, currentFocusedView: View, rootView: View) {
     val currentFocusedViewLocation = IntArray(2)
     currentFocusedView.getLocationOnScreen(currentFocusedViewLocation)
-    val currentFocusedViewDistanceToBottom = DisplayMetricsHolder.getScreenDisplayMetrics().heightPixels - (currentFocusedViewLocation[1] + currentFocusedView.height) - getNavigationBarHeight(context)
+    val currentFocusedViewDistanceToBottom = DisplayMetricsHolder.getScreenDisplayMetrics().heightPixels - (currentFocusedViewLocation[1] + currentFocusedView.height) - (getRootViewBottomInset(context) ?: 0)
 
     mBottomOffset = max(softInputHeight - currentFocusedViewDistanceToBottom, 0).toFloat() + mAvoidOffset
 
@@ -241,13 +240,13 @@ class AvoidSoftInputManager(private val context: Context) {
   private fun applyOffsetToScrollView(softInputHeight: Int, currentFocusedView: View, scrollView: ScrollView) {
     val scrollViewLocation = IntArray(2)
     scrollView.getLocationOnScreen(scrollViewLocation)
-    val scrollViewDistanceToBottom = DisplayMetricsHolder.getScreenDisplayMetrics().heightPixels - (scrollViewLocation[1] + scrollView.height) - getNavigationBarHeight(context)
+    val scrollViewDistanceToBottom = DisplayMetricsHolder.getScreenDisplayMetrics().heightPixels - (scrollViewLocation[1] + scrollView.height) - (getRootViewBottomInset(context) ?: 0)
 
     mBottomOffset = max(softInputHeight - scrollViewDistanceToBottom, 0).toFloat() + mAvoidOffset
 
     val currentFocusedViewLocation = IntArray(2)
     currentFocusedView.getLocationOnScreen(currentFocusedViewLocation)
-    val currentFocusedViewDistanceToBottom = DisplayMetricsHolder.getScreenDisplayMetrics().heightPixels - (currentFocusedViewLocation[1] + currentFocusedView.height) - getNavigationBarHeight(context)
+    val currentFocusedViewDistanceToBottom = DisplayMetricsHolder.getScreenDisplayMetrics().heightPixels - (currentFocusedViewLocation[1] + currentFocusedView.height) - (getRootViewBottomInset(context) ?: 0)
 
     val scrollToOffset = min(max(softInputHeight - currentFocusedViewDistanceToBottom, 0), (currentFocusedViewLocation[1] - scrollViewLocation[1]))
 

--- a/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputProvider.kt
+++ b/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputProvider.kt
@@ -67,7 +67,7 @@ class AvoidSoftInputProvider(): PopupWindow(), ViewTreeObserver.OnGlobalLayoutLi
 
   override fun onGlobalLayout() {
     mRootView.getWindowVisibleDisplayFrame(mRect)
-    val heightDiff = DisplayMetricsHolder.getScreenDisplayMetrics().heightPixels - mRect.bottom - getNavigationBarHeight(mReactContext)
+    val heightDiff = DisplayMetricsHolder.getScreenDisplayMetrics().heightPixels - mRect.bottom - (getRootViewBottomInset(mReactContext) ?: 0)
     val isSoftInputPotentiallyShown = mSoftInputHeight != heightDiff && heightDiff > mMinSoftInputHeightToDetect
 
     if (!isSoftInputPotentiallyShown) {

--- a/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputUtils.kt
+++ b/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputUtils.kt
@@ -1,10 +1,15 @@
 package com.reactnativeavoidsoftinput
 
 import android.content.Context
+import android.os.Build
 import android.view.View
+import android.view.WindowInsets
 import android.widget.ScrollView
+import androidx.annotation.RequiresApi
+import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.RootView
+import kotlin.math.min
 
 fun getScrollViewParent(view: View?, rootView: View): ScrollView? {
   if (view == null || view.parent == rootView || view.parent !is View) {
@@ -29,16 +34,6 @@ fun checkIfNestedInAvoidSoftInputView(view: View, rootView: RootView?): Boolean 
   return checkIfNestedInAvoidSoftInputView(view.parent as View, rootView)
 }
 
-fun getNavigationBarHeight(context: Context): Int {
-  var navigationBarHeight = 0
-  val resourceId: Int = context.resources.getIdentifier("navigation_bar_height", "dimen", "android")
-  if (resourceId > 0) {
-    navigationBarHeight = context.resources.getDimensionPixelSize(resourceId)
-  }
-
-  return navigationBarHeight
-}
-
 fun convertFromPixelToDIP(to: Int): Int {
   return PixelUtil.toDIPFromPixel(to.toFloat()).toInt()
 }
@@ -57,5 +52,44 @@ fun getReactRootView(view: View?): RootView? {
       return null
     }
     currentView = next
+  }
+}
+
+/**
+ * Get bottom navigation bar inset (if it exists), like in react-native-safe-area-context library
+ *
+ * https://github.com/th3rdwave/react-native-safe-area-context/blob/main/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.kt
+ */
+
+@RequiresApi(Build.VERSION_CODES.R)
+private fun getRootWindowBottomInsetR(rootView: View): Int? {
+  val insets =
+    rootView.rootWindowInsets?.getInsets(
+      WindowInsets.Type.statusBars() or
+        WindowInsets.Type.displayCutout() or
+        WindowInsets.Type.navigationBars())
+      ?: return null
+  return insets.bottom
+}
+
+@RequiresApi(Build.VERSION_CODES.M)
+@Suppress("DEPRECATION")
+private fun getRootWindowBottomInsetM(rootView: View): Int? {
+  val insets = rootView.rootWindowInsets ?: return null
+  return min(insets.systemWindowInsetBottom, insets.stableInsetBottom)
+}
+
+private fun getRootWindowBottomInsetCompat(rootView: View): Int? {
+  val visibleRect = android.graphics.Rect()
+  rootView.getWindowVisibleDisplayFrame(visibleRect)
+  return (rootView.height - visibleRect.bottom)
+}
+
+fun getRootViewBottomInset(reactContext: ReactContext): Int? {
+  val rootView = reactContext.currentActivity?.window?.decorView?.rootView ?: return null
+  return when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> getRootWindowBottomInsetR(rootView)
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> getRootWindowBottomInsetM(rootView)
+    else -> getRootWindowBottomInsetCompat(rootView)
   }
 }


### PR DESCRIPTION
So far, when calculating keyboard height and applied offset on Android,
navigation bar value was subtracted, even if navigation bar is separate from
screen, like in Nexus S device

This commit, calculates bottom inset based on WindowInsets API (and falls back
to View.getWindowVisibleDisplayFrame on Android API < 23) - that way,
if navigation bar is separate from screen, its height will not be subtracted
when calculating keyboard height and bottom inset.

Closes #37 