### PR TITLE
fix(#47): [Android] Not hidden space in scrollview after keyboard dismissal

### DIFF
--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -209,7 +209,7 @@ PODS:
   - React-jsinspector (0.67.3)
   - React-logger (0.67.3):
     - glog
-  - react-native-avoid-softinput (2.3.2):
+  - react-native-avoid-softinput (2.4.0):
     - React-Core
   - react-native-safe-area-context (3.4.1):
     - React-Core
@@ -452,7 +452,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 15ea57ead631a11fad57634ff69f78e797113a39
   React-jsinspector: 1e1e03345cf6d47779e2061d679d0a87d9ae73d8
   React-logger: 1e10789cb84f99288479ba5f20822ce43ced6ffe
-  react-native-avoid-softinput: fbab1797ea55339ebf56e9a6c221ee402ad765c4
+  react-native-avoid-softinput: 03d04d90639ed75b8311ca3091f8b9e3d9e3817d
   react-native-safe-area-context: 9e40fb181dac02619414ba1294d6c2a807056ab9
   React-perflogger: 93d3f142d6d9a46e635f09ba0518027215a41098
   React-RCTActionSheet: 87327c3722203cc79cf79d02fb83e7332aeedd18

--- a/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputManager.kt
+++ b/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputManager.kt
@@ -35,6 +35,7 @@ class AvoidSoftInputManager(private val context: ReactContext) {
   private var mListener: ((offset: Int) -> Unit)? = null
   private var mPreviousFocusedView: View? = null
   private var mPreviousRootView: View? = null
+  private var mPreviousScrollView: ScrollView? = null
   private var mScrollY: Int = 0
   private var mShouldCheckForAvoidSoftInputView = false
   private var mShowAnimationDelay: Long = 0
@@ -169,7 +170,7 @@ class AvoidSoftInputManager(private val context: ReactContext) {
   }
 
   private fun setOffset(from: Int, to: Int, currentFocusedView: View, rootView: View) {
-    val scrollView = getScrollViewParent(currentFocusedView, rootView)
+    val scrollView = getScrollViewParent(currentFocusedView, rootView) ?: mPreviousScrollView
     setScrollListener(scrollView, mOnScrollListener)
 
     if (scrollView != null) {
@@ -479,6 +480,7 @@ class AvoidSoftInputManager(private val context: ReactContext) {
             mScrollY = 0
             mCurrentBottomPadding = 0
             mBottomOffset = 0F
+            mPreviousScrollView = null
             mSoftInputVisible = false
           }
         })
@@ -526,6 +528,7 @@ class AvoidSoftInputManager(private val context: ReactContext) {
             onOffsetChanged(convertFromPixelToDIP(mBottomOffset.toInt()))
             mScrollY = scrollView.scrollY
             scrollView.smoothScrollTo(0, scrollView.scrollY + scrollToOffset)
+            mPreviousScrollView = scrollView
             mSoftInputVisible = true
           }
         })

--- a/packages/react-native-avoid-softinput/ios/AvoidSoftinput.xcodeproj/project.pbxproj
+++ b/packages/react-native-avoid-softinput/ios/AvoidSoftinput.xcodeproj/project.pbxproj
@@ -16,7 +16,8 @@
 		836FC8F326F9410B000ED360 /* BaseAvoidSoftInputEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836FC8F026F9410B000ED360 /* BaseAvoidSoftInputEvent.swift */; };
 		836FC8F426F9410B000ED360 /* AvoidSoftInputHiddenEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836FC8F126F9410B000ED360 /* AvoidSoftInputHiddenEvent.swift */; };
 		836FC8F526F9410B000ED360 /* AvoidSoftInputAppliedOffsetChangedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836FC8F226F9410B000ED360 /* AvoidSoftInputAppliedOffsetChangedEvent.swift */; };
-		83BAFE7A26F7D9BD002A8D53 /* AvoidSoftInputProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BAFE7926F7D9BC002A8D53 /* AvoidSoftInputProtocol.swift */; };
+		8382C4BF27F0780E00536B68 /* AvoidSoftInputHeightChangedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8382C4BE27F0780E00536B68 /* AvoidSoftInputHeightChangedEvent.swift */; };
+		8382C4C127F0781A00536B68 /* AvoidSoftInputManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8382C4C027F0781A00536B68 /* AvoidSoftInputManager.swift */; };
 		83BF566226F7995A009C1F11 /* AvoidSoftInputShownEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BF566026F7995A009C1F11 /* AvoidSoftInputShownEvent.swift */; };
 /* End PBXBuildFile section */
 
@@ -44,7 +45,8 @@
 		836FC8F026F9410B000ED360 /* BaseAvoidSoftInputEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BaseAvoidSoftInputEvent.swift; path = events/BaseAvoidSoftInputEvent.swift; sourceTree = "<group>"; };
 		836FC8F126F9410B000ED360 /* AvoidSoftInputHiddenEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AvoidSoftInputHiddenEvent.swift; path = events/AvoidSoftInputHiddenEvent.swift; sourceTree = "<group>"; };
 		836FC8F226F9410B000ED360 /* AvoidSoftInputAppliedOffsetChangedEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AvoidSoftInputAppliedOffsetChangedEvent.swift; path = events/AvoidSoftInputAppliedOffsetChangedEvent.swift; sourceTree = "<group>"; };
-		83BAFE7926F7D9BC002A8D53 /* AvoidSoftInputProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvoidSoftInputProtocol.swift; sourceTree = "<group>"; };
+		8382C4BE27F0780E00536B68 /* AvoidSoftInputHeightChangedEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AvoidSoftInputHeightChangedEvent.swift; path = events/AvoidSoftInputHeightChangedEvent.swift; sourceTree = "<group>"; };
+		8382C4C027F0781A00536B68 /* AvoidSoftInputManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvoidSoftInputManager.swift; sourceTree = "<group>"; };
 		83BF566026F7995A009C1F11 /* AvoidSoftInputShownEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AvoidSoftInputShownEvent.swift; path = events/AvoidSoftInputShownEvent.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -70,11 +72,11 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
-				83BAFE7926F7D9BC002A8D53 /* AvoidSoftInputProtocol.swift */,
 				83BF566426F7996E009C1F11 /* events */,
 				83693C9B26973C8800AF5E7E /* AvoidSoftinput-Bridging-Header.h */,
 				83693C9726973C8800AF5E7E /* AvoidSoftInput.m */,
 				83693C9826973C8800AF5E7E /* AvoidSoftInput.swift */,
+				8382C4C027F0781A00536B68 /* AvoidSoftInputManager.swift */,
 				83693C9A26973C8800AF5E7E /* AvoidSoftInputUtils.swift */,
 				83693C9926973C8800AF5E7E /* AvoidSoftInputView.swift */,
 				83693C9D26973C8800AF5E7E /* AvoidSoftInputViewManager.m */,
@@ -86,6 +88,7 @@
 		83BF566426F7996E009C1F11 /* events */ = {
 			isa = PBXGroup;
 			children = (
+				8382C4BE27F0780E00536B68 /* AvoidSoftInputHeightChangedEvent.swift */,
 				836FC8F226F9410B000ED360 /* AvoidSoftInputAppliedOffsetChangedEvent.swift */,
 				836FC8F126F9410B000ED360 /* AvoidSoftInputHiddenEvent.swift */,
 				836FC8F026F9410B000ED360 /* BaseAvoidSoftInputEvent.swift */,
@@ -151,9 +154,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8382C4C127F0781A00536B68 /* AvoidSoftInputManager.swift in Sources */,
 				836FC8F526F9410B000ED360 /* AvoidSoftInputAppliedOffsetChangedEvent.swift in Sources */,
+				8382C4BF27F0780E00536B68 /* AvoidSoftInputHeightChangedEvent.swift in Sources */,
 				83693CA126973C8800AF5E7E /* AvoidSoftInputUtils.swift in Sources */,
-				83BAFE7A26F7D9BD002A8D53 /* AvoidSoftInputProtocol.swift in Sources */,
 				83693CA326973C8800AF5E7E /* AvoidSoftInputViewManager.m in Sources */,
 				83693C9F26973C8800AF5E7E /* AvoidSoftInput.swift in Sources */,
 				83693C9E26973C8800AF5E7E /* AvoidSoftInput.m in Sources */,


### PR DESCRIPTION
This pull request resolves #47 

**Description**

<!-- Describe, what this pull request is solving. -->

There was a different behavior when applied padding had to be removed from
scroll view after user used only soft keyboard or typed sth with physical
keyboard on Android.

When physical keyboard was used, either by submitting with Enter key,
or just by typing some character, scrollview which had applied padding
couldn't be find inside AvoidSoftInputManager.kt

Solution:
As it is done for rootview, reference to scrollview that has applied
padding, is saved. When manager cannot find scrollview by traversing
rootview, it looks to saved reference.

**Affected platforms**

- [X] Android
- [] iOS

**Test plan/screenshots/videos**

<!-- Demonstrate steps to check proposed changes. Add screenshots and/or videos if there are UI changes. -->
Try to submit input with physical keyboard