### PR TITLE
fix(#52): not reset internal values on Android

### DIFF
--- a/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputManager.kt
+++ b/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputManager.kt
@@ -106,6 +106,16 @@ class AvoidSoftInputManager(private val context: ReactContext) {
     val currentFocusedView = mCurrentFocusedView ?: mPreviousFocusedView
 
     if (!mIsEnabled || currentFocusedView == null) {
+      if (mSoftInputVisible && to == 0) {
+        // Handle case when padding was applied but focused view was unmounted,
+        // or screen was dismissed from navigation stack and internal values were not reset
+        mScrollY = 0
+        mCurrentBottomPadding = 0
+        mBottomOffset = 0F
+        mPreviousRootView = null
+        mPreviousScrollView = null
+        mSoftInputVisible = false
+      }
       return
     }
 

--- a/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputUtils.kt
+++ b/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputUtils.kt
@@ -1,7 +1,7 @@
 package com.reactnativeavoidsoftinput
 
-import android.content.Context
 import android.os.Build
+import android.util.Log
 import android.view.View
 import android.view.WindowInsets
 import android.widget.ScrollView
@@ -91,5 +91,12 @@ fun getRootViewBottomInset(reactContext: ReactContext): Int? {
     Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> getRootWindowBottomInsetR(rootView)
     Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> getRootWindowBottomInsetM(rootView)
     else -> getRootWindowBottomInsetCompat(rootView)
+  }
+}
+
+object ReactNativeAvoidSoftInputLogger {
+  @JvmStatic
+  fun log(tag: String, message: String) {
+    Log.d(tag, message)
   }
 }


### PR DESCRIPTION
This pull request resolves #52 

**Description**

<!-- Describe, what this pull request is solving. -->

When user dismissed screen with focused input and visible keyboard,
internal values in AvoidSoftInputManager were not reset, because
focused view was already destroyed

Solution:
When there is event with final keyboard height value equal 0 and
mSoftInputVisible is still `true`, and focused view is null,
there will be early return, so just reset values to default ones

**Affected platforms**

- [x] Android
- [] iOS

**Test plan/screenshots/videos**

<!-- Demonstrate steps to check proposed changes. Add screenshots and/or videos if there are UI changes. -->

- Open FormExample in example app. 
- Tap input
- Press back button inside header
- Revisit FormExample and tap input
- It shouldn't cover whole screen with padding, as it was in linked issue