### PR TITLE
fix(#54): incorrect offset when screen swiping on iOS

### DIFF
--- a/packages/app/src/navigation/index.tsx
+++ b/packages/app/src/navigation/index.tsx
@@ -17,7 +17,7 @@ import type { RootStackParamList } from './types';
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export const Navigation: React.FC = () => {
-  return <Stack.Navigator>
+  return <Stack.Navigator screenOptions={{ gestureEnabled: true, fullScreenGestureEnabled: true }}>
     <Stack.Screen name={ROUTES.Home} component={HomeScreen} />
     <Stack.Screen name={ROUTES.BottomSheet} component={BottomSheetExample} />
     <Stack.Screen name={ROUTES.CustomAnimationConfigModule} component={CustomAnimationConfigModuleExample} />


### PR DESCRIPTION
This pull request resolves #54 

**Description**

<!-- Describe, what this pull request is solving. -->

When user tried to swipe-to-dismiss screen on iOS, but finally aborted it, offset was incorrectly reapplied.

This PR checks if offset was actually removed when user screen swipes.

**Affected platforms**

- [ ] Android
- [x] iOS

**Test plan/screenshots/videos**

<!-- Demonstrate steps to check proposed changes. Add screenshots and/or videos if there are UI changes. -->

Open example app on iOS and try to screen swipe when text input is focused
