### PR TITLE
fix(#81): crashes with API < 23 & View.OnScrollChangeListener

### DIFF
--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -209,7 +209,7 @@ PODS:
   - React-jsinspector (0.67.3)
   - React-logger (0.67.3):
     - glog
-  - react-native-avoid-softinput (2.4.4):
+  - react-native-avoid-softinput (2.4.5):
     - React-Core
   - react-native-safe-area-context (3.4.1):
     - React-Core
@@ -455,7 +455,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 15ea57ead631a11fad57634ff69f78e797113a39
   React-jsinspector: 1e1e03345cf6d47779e2061d679d0a87d9ae73d8
   React-logger: 1e10789cb84f99288479ba5f20822ce43ced6ffe
-  react-native-avoid-softinput: 67e0de5aecd392f91ae8e7cc9dfa10582071c35c
+  react-native-avoid-softinput: 1d2b0535506d29570bf55e46ea4c28b36d0ab3a2
   react-native-safe-area-context: 9e40fb181dac02619414ba1294d6c2a807056ab9
   React-perflogger: 93d3f142d6d9a46e635f09ba0518027215a41098
   React-RCTActionSheet: 87327c3722203cc79cf79d02fb83e7332aeedd18

--- a/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputManager.kt
+++ b/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputManager.kt
@@ -57,7 +57,7 @@ class AvoidSoftInputManager(private val context: ReactContext) {
       return@OnGlobalFocusChangeListener
     }
     val scrollView = getScrollViewParent(currentFocusedView, rootView) ?: return@OnGlobalFocusChangeListener
-    setScrollListener(scrollView, mOnScrollListener)
+    setScrollListener(scrollView)
     val currentFocusedViewLocation = IntArray(2)
     currentFocusedView.getLocationOnScreen(currentFocusedViewLocation)
     val currentFocusedViewDistanceToBottom = DisplayMetricsHolder.getScreenDisplayMetrics().heightPixels - (currentFocusedViewLocation[1] + currentFocusedView.height) - (getRootViewBottomInset(context) ?: 0)
@@ -68,16 +68,15 @@ class AvoidSoftInputManager(private val context: ReactContext) {
     scrollView.smoothScrollTo(0, scrollView.scrollY + scrollToOffset)
   }
 
-  private val mOnScrollListener = View.OnScrollChangeListener { _, _, scrollY, _, _ ->
-    if (mCurrentFocusedView == null) {
-      return@OnScrollChangeListener
-    }
-    mScrollY = scrollY
-  }
-
-  private fun setScrollListener(scrollView: ScrollView?, listener: View.OnScrollChangeListener?) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      scrollView?.setOnScrollChangeListener(listener)
+  private fun setScrollListener(scrollView: ScrollView?) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && scrollView != null) {
+      val listener = View.OnScrollChangeListener { _, _, scrollY, _, _ ->
+        if (mCurrentFocusedView == null) {
+          return@OnScrollChangeListener
+        }
+        mScrollY = scrollY
+      }
+      scrollView.setOnScrollChangeListener(listener)
     }
   }
 
@@ -181,7 +180,7 @@ class AvoidSoftInputManager(private val context: ReactContext) {
 
   private fun setOffset(from: Int, to: Int, currentFocusedView: View, rootView: View) {
     val scrollView = getScrollViewParent(currentFocusedView, rootView) ?: mPreviousScrollView
-    setScrollListener(scrollView, mOnScrollListener)
+    setScrollListener(scrollView)
 
     if (scrollView != null) {
       setOffsetInScrollView(from, to, currentFocusedView, scrollView)


### PR DESCRIPTION
This pull request resolves #81 

**Description**

<!-- Describe, what this pull request is solving. -->

move `View.OnScrollChangeListener` listener to `setScrollListener` method (inside if API >= 23 condition)

**Affected platforms**

- [x] Android
- [ ] iOS

**Test plan/screenshots/videos**

<!-- Demonstrate steps to check proposed changes. Add screenshots and/or videos if there are UI changes. -->

Run on simulator/device with Android API < 23
