### PR TITLE
chore: create reusable npm release workflow

### DIFF
--- a/.github/workflows/npm-release-template.yml
+++ b/.github/workflows/npm-release-template.yml
@@ -1,15 +1,24 @@
-name: Release to NPM
+name: Publish to NPM reusable workflow (template)
 
-on: workflow_dispatch
+on:
+  workflow_call:
+    inputs:
+      increment:
+        description: Release increment (major|minor|patch)
+        type: string
+      pre_release:
+        description: Is release candidate?
+        type: boolean
+    secrets:
+      npm_token:
+        required: true
 
 jobs:
-  npm-release:
+  release:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [16.x]
-
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -29,7 +38,12 @@ jobs:
           git config --global user.email "luigimario1913@gmail.com"
           git config --global user.name "Mateusz Mędrek"
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
-          yarn release --ci --npm.skipChecks
+          if [[ ${{ inputs.pre_release }} == true ]]
+          then
+            yarn release --preRelease=rc --ci --npm.skipChecks
+          else
+            yarn release --increment=${{ inputs.increment }} --ci --npm.skipChecks
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.npm_token }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,12 @@
+name: Pre-release to NPM
+
+on: 
+  workflow_dispatch:
+
+jobs:
+  npm-release-major:
+    uses: mateusz1913/react-native-avoid-softinput/.github/workflows/npm-release-template.yml@master
+    with:
+      pre_release: true
+    secrets:
+      npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-major.yml
+++ b/.github/workflows/release-major.yml
@@ -1,0 +1,12 @@
+name: Major release to NPM
+
+on: 
+  workflow_dispatch:
+
+jobs:
+  npm-release-major:
+    uses: mateusz1913/react-native-avoid-softinput/.github/workflows/npm-release-template.yml@master
+    with:
+      increment: major
+    secrets:
+      npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-minor.yml
+++ b/.github/workflows/release-minor.yml
@@ -1,0 +1,12 @@
+name: Minor release to NPM
+
+on: 
+  workflow_dispatch:
+
+jobs:
+  npm-release-major:
+    uses: mateusz1913/react-native-avoid-softinput/.github/workflows/npm-release-template.yml@master
+    with:
+      increment: minor
+    secrets:
+      npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -1,0 +1,12 @@
+name: Patch release to NPM
+
+on: 
+  workflow_dispatch:
+
+jobs:
+  npm-release-major:
+    uses: mateusz1913/react-native-avoid-softinput/.github/workflows/npm-release-template.yml@master
+    with:
+      increment: patch
+    secrets:
+      npm_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request resolves #83 

**Description**

<!-- Describe, what this pull request is solving. -->

create reusable npm release workflow (major|minor|patch|pre-release)