### PR TITLE
fix(#90): 'onAnimationEnd' overrides nothing(compileSdkVersion>=33)

### DIFF
--- a/packages/react-native-avoid-softinput/android/gradle.properties
+++ b/packages/react-native-avoid-softinput/android/gradle.properties
@@ -1,4 +1,4 @@
-AvoidSoftinput_kotlinVersion=1.3.50
-AvoidSoftinput_compileSdkVersion=29
-AvoidSoftinput_buildToolsVersion=29.0.2
-AvoidSoftinput_targetSdkVersion=29
+AvoidSoftinput_kotlinVersion=1.6.10
+AvoidSoftinput_compileSdkVersion=31
+AvoidSoftinput_buildToolsVersion=30.0.2
+AvoidSoftinput_targetSdkVersion=31

--- a/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputManager.kt
+++ b/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputManager.kt
@@ -238,7 +238,7 @@ class AvoidSoftInputManager(private val context: ReactContext) {
         startDelay = mHideAnimationDelay
         interpolator = mAnimationInterpolator
         addListener(object: AnimatorListenerAdapter() {
-          override fun onAnimationEnd(animation: Animator?) {
+          override fun onAnimationEnd(animation: Animator) {
             super.onAnimationEnd(animation)
             mIsHideAnimationRunning = false
             mHideValueAnimator = null
@@ -276,7 +276,7 @@ class AvoidSoftInputManager(private val context: ReactContext) {
         startDelay = mShowAnimationDelay
         interpolator = mAnimationInterpolator
         addListener(object: AnimatorListenerAdapter() {
-          override fun onAnimationEnd(animation: Animator?) {
+          override fun onAnimationEnd(animation: Animator) {
             super.onAnimationEnd(animation)
             mIsShowAnimationRunning = false
             mShowValueAnimator = null
@@ -307,7 +307,7 @@ class AvoidSoftInputManager(private val context: ReactContext) {
         startDelay = mHideAnimationDelay
         interpolator = mAnimationInterpolator
         addListener(object: AnimatorListenerAdapter() {
-          override fun onAnimationEnd(animation: Animator?) {
+          override fun onAnimationEnd(animation: Animator) {
             super.onAnimationEnd(animation)
             mIsHideAnimationRunning = false
             mHideValueAnimator = null
@@ -350,7 +350,7 @@ class AvoidSoftInputManager(private val context: ReactContext) {
         startDelay = mShowAnimationDelay
         interpolator = mAnimationInterpolator
         addListener(object: AnimatorListenerAdapter() {
-          override fun onAnimationEnd(animation: Animator?) {
+          override fun onAnimationEnd(animation: Animator) {
             super.onAnimationEnd(animation)
             mIsShowAnimationRunning = false
             mShowValueAnimator = null
@@ -425,7 +425,7 @@ class AvoidSoftInputManager(private val context: ReactContext) {
         startDelay = mHideAnimationDelay
         interpolator = mAnimationInterpolator
         addListener(object: AnimatorListenerAdapter() {
-          override fun onAnimationEnd(animation: Animator?) {
+          override fun onAnimationEnd(animation: Animator) {
             super.onAnimationEnd(animation)
             mIsHideAnimationRunning = false
             mHideValueAnimator = null
@@ -465,7 +465,7 @@ class AvoidSoftInputManager(private val context: ReactContext) {
         startDelay = mShowAnimationDelay
         interpolator = mAnimationInterpolator
         addListener(object: AnimatorListenerAdapter() {
-          override fun onAnimationEnd(animation: Animator?) {
+          override fun onAnimationEnd(animation: Animator) {
             super.onAnimationEnd(animation)
             mIsShowAnimationRunning = false
             mShowValueAnimator = null
@@ -497,7 +497,7 @@ class AvoidSoftInputManager(private val context: ReactContext) {
         startDelay = mHideAnimationDelay
         interpolator = mAnimationInterpolator
         addListener(object: AnimatorListenerAdapter() {
-          override fun onAnimationEnd(animation: Animator?) {
+          override fun onAnimationEnd(animation: Animator) {
             super.onAnimationEnd(animation)
             mIsHideAnimationRunning = false
             mHideValueAnimator = null
@@ -547,7 +547,7 @@ class AvoidSoftInputManager(private val context: ReactContext) {
         startDelay = mShowAnimationDelay
         interpolator = mAnimationInterpolator
         addListener(object: AnimatorListenerAdapter() {
-          override fun onAnimationEnd(animation: Animator?) {
+          override fun onAnimationEnd(animation: Animator) {
             super.onAnimationEnd(animation)
             mIsShowAnimationRunning = false
             mShowValueAnimator = null


### PR DESCRIPTION
This pull request resolves #90 

**Description**

<!-- Describe, what this pull request is solving. -->

fix 'onAnimationEnd' overrides nothing(compileSdkVersion>=33) - Type mismatch: inferred type is Animator? but Animator was expected

**Affected platforms**

- [X] Android
- [ ] iOS

**Test plan/screenshots/videos**

<!-- Demonstrate steps to check proposed changes. Add screenshots and/or videos if there are UI changes. -->

Run example app with compileSdkVersion and targetSdkVersion set to 33
