### PR TITLE
Fix:(https://github.com/mateusz1913/react-native-avoid-softinput/issues/90#issuecomment-1272523730) 'onAnimationEnd' overrides nothing

### DIFF
--- a/packages/react-native-avoid-softinput/android/gradle.properties
+++ b/packages/react-native-avoid-softinput/android/gradle.properties
@@ -1,6 +1,6 @@
 AvoidSoftinput_kotlinVersion=1.6.10
-AvoidSoftinput_compileSdkVersion=31
-AvoidSoftinput_buildToolsVersion=30.0.2
-AvoidSoftinput_targetSdkVersion=31
+AvoidSoftinput_compileSdkVersion=33
+AvoidSoftinput_buildToolsVersion=33.0.0
+AvoidSoftinput_targetSdkVersion=33
 AvoidSoftinput_androidXCoreKtxVersion=1.6.0
 AvoidSoftinput_kotlinCoroutinesVersion=1.6.0

--- a/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/animations/AnimationHandlerImpl.kt
+++ b/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/animations/AnimationHandlerImpl.kt
@@ -83,7 +83,7 @@ class AnimationHandlerImpl : AnimationHandler {
         startDelay = if (isShowAnimation) mShowAnimationDelay else mHideAnimationDelay
         interpolator = mAnimationInterpolator
         addListener(object : AnimatorListenerAdapter() {
-          override fun onAnimationEnd(animation: Animator?) {
+          override fun onAnimationEnd(animation: Animator) {
             super.onAnimationEnd(animation)
             if (isShowAnimation) {
               mIsShowAnimationRunning = false


### PR DESCRIPTION
Fix: Type mismatch: inferred type is Animator? but Animator was expected

(For RN 0.70.2 and compileSDKVersion = 33)
