### PR TITLE
fix(#125): not necessary `setEnabled(true)` in sticky footer docs

### DIFF
--- a/docs/docs/recipes/STICKY_FOOTER.mdx
+++ b/docs/docs/recipes/STICKY_FOOTER.mdx
@@ -29,10 +29,8 @@ export const StickyFooterExample: React.FC = () => {
 
   const onFocusEffect = useCallback(() => {
     AvoidSoftInput.setShouldMimicIOSBehavior(true); // <---- Tell Android that library will handle keyboard insets manually to match iOS behavior
-    AvoidSoftInput.setEnabled(true);
 
     return () => {
-      AvoidSoftInput.setEnabled(false);
       AvoidSoftInput.setShouldMimicIOSBehavior(false);
     };
   }, []);

--- a/docs/versioned_docs/version-2.0.x/recipes/STICKY_FOOTER.mdx
+++ b/docs/versioned_docs/version-2.0.x/recipes/STICKY_FOOTER.mdx
@@ -29,10 +29,8 @@ export const StickyFooterExample: React.FC = () => {
 
   const onFocusEffect = useCallback(() => {
     AvoidSoftInput.setAdjustNothing();
-    AvoidSoftInput.setEnabled(true);
 
     return () => {
-      AvoidSoftInput.setEnabled(false);
       AvoidSoftInput.setDefaultAppSoftInputMode();
     };
   }, []);

--- a/docs/versioned_docs/version-3.0.x/recipes/STICKY_FOOTER.mdx
+++ b/docs/versioned_docs/version-3.0.x/recipes/STICKY_FOOTER.mdx
@@ -29,10 +29,8 @@ export const StickyFooterExample: React.FC = () => {
 
   const onFocusEffect = useCallback(() => {
     AvoidSoftInput.setShouldMimicIOSBehavior(true); // <---- Tell Android that library will handle keyboard insets manually to match iOS behavior
-    AvoidSoftInput.setEnabled(true);
 
     return () => {
-      AvoidSoftInput.setEnabled(false);
       AvoidSoftInput.setShouldMimicIOSBehavior(false);
     };
   }, []);


### PR DESCRIPTION
This pull request resolves #125 

**Description**

<!-- Describe, what this pull request is solving. -->

remove not necessary `setEnabled(true)` in sticky footer docs
