### PR TITLE
refactor(#118): global properties to react-native stable APIs

### DIFF
--- a/packages/react-native-avoid-softinput/src/AvoidSoftInputModule.ts
+++ b/packages/react-native-avoid-softinput/src/AvoidSoftInputModule.ts
@@ -1,17 +1,5 @@
-import { NativeModules } from 'react-native';
-
 import type { AvoidSoftInputNativeModuleType } from './types';
 
-declare global {
-  // eslint-disable-next-line no-var, no-underscore-dangle
-  var __turboModuleProxy: unknown;
-}
-
-// eslint-disable-next-line no-underscore-dangle
-const isTurboModuleEnabled = global.__turboModuleProxy !== null;
-
-const myModule: AvoidSoftInputNativeModuleType = isTurboModuleEnabled
-  ? require('./NativeAvoidSoftInputModule').default
-  : NativeModules.AvoidSoftInput;
-
+const myModule: AvoidSoftInputNativeModuleType = require('./NativeAvoidSoftInputModule').default;
+  
 export default myModule;

--- a/packages/react-native-avoid-softinput/src/NativeAvoidSoftInputView.ts
+++ b/packages/react-native-avoid-softinput/src/NativeAvoidSoftInputView.ts
@@ -1,17 +1,7 @@
 import type { HostComponent } from 'react-native';
-import { requireNativeComponent } from 'react-native';
 
 import type { AvoidSoftInputViewProps } from './types';
 
-declare global {
-  // eslint-disable-next-line no-var
-  var nativeFabricUIManager: unknown;
-}
-
-const isFabricEnabled = global.nativeFabricUIManager !== null;
-
-const component: HostComponent<AvoidSoftInputViewProps> = isFabricEnabled
-  ? require('./AvoidSoftInputViewNativeComponent').default
-  : requireNativeComponent('AvoidSoftInputView');
+const component: HostComponent<AvoidSoftInputViewProps> = require('./AvoidSoftInputViewNativeComponent').default;
 
 export default component;


### PR DESCRIPTION
This pull request resolves #118 

**Description**

<!-- Describe, what this pull request is solving. -->

- remove global.__turboModuleProxy
- remove global.nativeFabricUIManager

**Affected platforms**

- [X] Android
- [X] iOS
