### PR TITLE
refactor(#124): folly version not needed in Fabric from RN 0.70

### DIFF
--- a/packages/react-native-avoid-softinput/react-native-avoid-softinput.podspec
+++ b/packages/react-native-avoid-softinput/react-native-avoid-softinput.podspec
@@ -8,7 +8,6 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
-folly_version = '2021.07.22.00'
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
@@ -44,7 +43,7 @@ Pod::Spec.new do |s|
 
     s.dependency "React-RCTFabric"
     s.dependency "React-Codegen"
-    s.dependency "RCT-Folly", folly_version
+    s.dependency "RCT-Folly"
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"


### PR DESCRIPTION
This pull request resolves #124 

**Description**

<!-- Describe, what this pull request is solving. -->

- remove folly version not needed in Fabric from RN 0.70

**Affected platforms**

- [ ] Android
- [X] iOS
