### PR TITLE
fix(#131): fix native crash when the subviews array is empty

### DIFF
--- a/packages/react-native-avoid-softinput/ios/AvoidSoftInputObjCPPUtils.mm
+++ b/packages/react-native-avoid-softinput/ios/AvoidSoftInputObjCPPUtils.mm
@@ -25,7 +25,8 @@
 #else
         RCTRootView
 #endif
-        class]])
+        class]]
+      && viewController.view.subviews.count > 0)
     {
     return viewController.view.subviews[0];
   }


### PR DESCRIPTION
This pull request resolves (#131)

**Description**

<!-- Describe, what this pull request is solving. -->
Added a condition to check whether the subviews array is empty or not. It fixes application crashes in case the subviews array comes empty.

**Affected platforms**

- [ ] Android
- [x] iOS

**Test plan/screenshots/videos**

<!-- Demonstrate steps to check proposed changes. Add screenshots and/or videos if there are UI changes. -->
