### PR TITLE
fix(#141): missing podspec in NPM package

### DIFF
--- a/packages/react-native-avoid-softinput/package.json
+++ b/packages/react-native-avoid-softinput/package.json
@@ -36,7 +36,7 @@
     "android",
     "ios",
     "cpp",
-    "react-native-avoid-softinput.podspec",
+    "ReactNativeAvoidSoftinput.podspec",
     "jest",
     "LICENSE",
     "!lib/typescript/example",


### PR DESCRIPTION
This pull request resolves #141 

**Description**

<!-- Describe, what this pull request is solving. -->

After renaming podspec file, it wasn't updated in package.json files field, so there's no podspec in 3.1.0 in NPM

**Affected platforms**

- [ ] Android
- [X] iOS
