### PR TITLE
fix(#144): animation crash on Android

### DIFF
--- a/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/animations/AnimationHandlerImpl.kt
+++ b/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/animations/AnimationHandlerImpl.kt
@@ -69,15 +69,15 @@ class AnimationHandlerImpl : AnimationHandler {
     animationEnd: Float,
     onAnimatorEventListener: OnAnimatorEventListener
   ) {
-    mIsHideAnimationCancelled = isShowAnimation
-    mIsShowAnimationCancelled = !isShowAnimation
-    if (isShowAnimation) {
-      mHideValueAnimator?.cancel()
-    } else {
-      mShowValueAnimator?.cancel()
-    }
-    onAnimatorEventListener.onBeforeStart()
     UiThreadUtil.runOnUiThread {
+      mIsHideAnimationCancelled = isShowAnimation
+      mIsShowAnimationCancelled = !isShowAnimation
+      if (isShowAnimation) {
+        mHideValueAnimator?.cancel()
+      } else {
+        mShowValueAnimator?.cancel()
+      }
+      onAnimatorEventListener.onBeforeStart()
       val animator = ValueAnimator.ofFloat(animationStart, animationEnd).apply {
         duration = if (isShowAnimation) mShowAnimationDuration else mHideAnimationDuration
         startDelay = if (isShowAnimation) mShowAnimationDelay else mHideAnimationDelay


### PR DESCRIPTION
This pull request resolves #144 

**Description**

<!-- Describe, what this pull request is solving. -->

Move code in `runAnimator` method to run on UI thread

**Affected platforms**

- [X] Android
- [ ] iOS

**Test plan/screenshots/videos**

<!-- Demonstrate steps to check proposed changes. Add screenshots and/or videos if there are UI changes. -->

Run one of examples and try to quickly cancel the animation (show and quickly hide the keyboard)
