### PR TITLE
fix: android scrollview will scroll to 0 when unfocused

### DIFF
--- a/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputManager.kt
+++ b/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/AvoidSoftInputManager.kt
@@ -53,7 +53,7 @@ class AvoidSoftInputManager(
 
   // MARK: Private methods
   private fun onFocus(oldView: View?, newView: View?) {
-    if (!mSoftInputVisible || !mIsEnabled) {
+    if (!mIsEnabled) {
       return
     }
     val reactRootView = getNearestParentReactRootView(newView)
@@ -61,6 +61,11 @@ class AvoidSoftInputManager(
       return
     }
     val scrollView = getScrollViewParent(newView, reactRootView) ?: return
+    mScrollY = scrollView.scrollY
+    if (!mSoftInputVisible) {
+      return
+    }
+
     setScrollListenerCompat(scrollView) {
       if (currentFocusedView != null) {
         mScrollY = it
@@ -70,7 +75,6 @@ class AvoidSoftInputManager(
 
     val scrollToOffset = max(mCompleteSoftInputHeight - currentFocusedViewDistanceToBottom, 0)
 
-    mScrollY = scrollView.scrollY
     scrollView.smoothScrollTo(0, scrollView.scrollY + scrollToOffset)
   }
 

--- a/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/animations/AnimationHandlerImpl.kt
+++ b/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/animations/AnimationHandlerImpl.kt
@@ -50,7 +50,7 @@ class AnimationHandlerImpl : AnimationHandler {
     currentFocusedView.getLocationOnScreen(currentFocusedViewLocation)
     val currentFocusedViewDistanceToBottom = getViewDistanceToBottomEdge(scrollView)
 
-    return min(max(softInputHeight - currentFocusedViewDistanceToBottom, 0), (currentFocusedViewLocation[1] - scrollViewLocation[1]))
+    return min(max(softInputHeight - currentFocusedViewDistanceToBottom, 0), max(currentFocusedViewLocation[1] - scrollViewLocation[1], 0))
   }
 
   private fun onScrollViewAnimationUpdate(scrollView: ScrollView, animatedOffset: Float) {


### PR DESCRIPTION
This pull request resolves scrollview will scroll to 0 sometimes in android

**Description**

when function `onfocus()` called, the `mSoftInputVisible` sometimes will be false, so the `mScrollY` can't be updated when onFocus. Then  if user don't scroll the content(no ScrollListener callback, no `mScrollY` update), instead, he collapse keyboard immediately, in `removeOffsetInScrollView()` method, scrollview will scroll to 0(because `mScrollY` now is 0).

**Affected platforms**

- [x] Android
- [ ] iOS
