### PR TITLE
fix: auto import components

### DIFF
--- a/packages/react-native-avoid-softinput/src/index.tsx
+++ b/packages/react-native-avoid-softinput/src/index.tsx
@@ -1,8 +1,8 @@
-import { AvoidSoftInput } from "./AvoidSoftInput";
-import { AvoidSoftInputView } from "./AvoidSoftInputView";
-export * from "./AvoidSoftInput";
-export * from "./AvoidSoftInputView";
-export * from "./hooks";
-export * from "./types";
+import { AvoidSoftInput } from './AvoidSoftInput';
+import { AvoidSoftInputView } from './AvoidSoftInputView';
+export * from './AvoidSoftInput';
+export * from './AvoidSoftInputView';
+export * from './hooks';
+export * from './types';
 
 export { AvoidSoftInput, AvoidSoftInputView };

--- a/packages/react-native-avoid-softinput/src/index.tsx
+++ b/packages/react-native-avoid-softinput/src/index.tsx
@@ -1,5 +1,7 @@
-import AvoidSoftInput from "./AvoidSoftInput";
-import AvoidSoftInputView from "./AvoidSoftInputView";
+import { AvoidSoftInput } from "./AvoidSoftInput";
+import { AvoidSoftInputView } from "./AvoidSoftInputView";
+export * from "./AvoidSoftInput";
+export * from "./AvoidSoftInputView";
 export * from "./hooks";
 export * from "./types";
 

--- a/packages/react-native-avoid-softinput/src/index.tsx
+++ b/packages/react-native-avoid-softinput/src/index.tsx
@@ -1,4 +1,6 @@
-export * from './AvoidSoftInput';
-export * from './AvoidSoftInputView';
-export * from './hooks';
-export * from './types';
+import AvoidSoftInput from "./AvoidSoftInput";
+import AvoidSoftInputView from "./AvoidSoftInputView";
+export * from "./hooks";
+export * from "./types";
+
+export { AvoidSoftInput, AvoidSoftInputView };


### PR DESCRIPTION
This pull request resolves #168 

**Auto import issue #168**

<!-- User had to manually add import line at the time as automatic imports were not supported -->

**Affected platforms**

-  Android
-  iOS

<!-- To reproduce, you can just add this library to your react-native project and try to import it. -->
