### PR TITLE
fix(#175): unnecessary scroll even when it's not needed

### DIFF
--- a/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/animations/AnimationHandlerImpl.kt
+++ b/packages/react-native-avoid-softinput/android/src/main/java/com/reactnativeavoidsoftinput/animations/AnimationHandlerImpl.kt
@@ -48,7 +48,7 @@ class AnimationHandlerImpl : AnimationHandler {
 
     val currentFocusedViewLocation = IntArray(2)
     currentFocusedView.getLocationOnScreen(currentFocusedViewLocation)
-    val currentFocusedViewDistanceToBottom = getViewDistanceToBottomEdge(scrollView)
+    val currentFocusedViewDistanceToBottom = getViewDistanceToBottomEdge(currentFocusedView)
 
     return min(max(softInputHeight - currentFocusedViewDistanceToBottom, 0), max(currentFocusedViewLocation[1] - scrollViewLocation[1], 0))
   }


### PR DESCRIPTION
This pull request resolves #175 

**Description**

<!-- Describe, what this pull request is solving. -->

Because of passing wrong view to the `getScrollToOffset` measurement util (scrollview instead of currenly focused input), the scrollview was being scrolled even when the input was not being covered by the keyboard.

**Affected platforms**

- [X] Android
- [ ] iOS
