### PR TITLE
fix: make Android new arch build work RN 0.75

### DIFF
--- a/packages/react-native-avoid-softinput/android/build.gradle
+++ b/packages/react-native-avoid-softinput/android/build.gradle
@@ -27,10 +27,36 @@ if (project == rootProject) {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
+def safeAppExtGet(prop, fallback) {
+  def appProject = rootProject.allprojects.find { it.plugins.hasPlugin('com.android.application') }
+  appProject?.ext?.has(prop) ? appProject.ext.get(prop) : fallback
+}
+
+def resolveReactNativeDirectory() {
+  def reactNativeLocation = safeAppExtGet("REACT_NATIVE_NODE_MODULES_DIR", null)
+  if (reactNativeLocation != null) {
+    return file(reactNativeLocation)
+  }
+
+  def reactNativeFromAppNodeModules = file("${projectDir}/../../react-native")
+  if (reactNativeFromAppNodeModules.exists()) {
+    return reactNativeFromAppNodeModules
+  }
+
+  def reactNativeFromProjectNodeModules = file("${rootProject.projectDir}/../node_modules/react-native")
+  if (reactNativeFromProjectNodeModules.exists()) {
+    return reactNativeFromProjectNodeModules
+  }
+
+  throw new GradleException(
+    "[RNAvoidSoftInput] Unable to resolve react-native location in node_modules. You should add project extension property (in `app/build.gradle`) `REACT_NATIVE_NODE_MODULES_DIR` with path to react-native."
+  )
+}
+
 if (isNewArchitectureEnabled()) {
   apply plugin: "com.facebook.react"
 
-  def reactNativeDirectory = project.ext.resolveReactNativeDirectory()
+  def reactNativeDirectory = resolveReactNativeDirectory()
 
   react {
     reactNativeDir = file(reactNativeDirectory)


### PR DESCRIPTION
This pull request resolves an issue when building on Android with the "New Architecture" enabled for React Native 0.75.

**Description**

I recently updated all of my apps to React Native 0.75 and I tried to enable the "New Architecture" on most of them. One of these apps uses the `react-native-avoid-softinput` package which did not build properly on Android. 

I tried to dig through the issue and found out that it failed while trying to find a non-existent `resolveReactNativeDirectory()` function in `project.ext`. I'm pretty sure this worked as expected in previous version of React Native with the "New Architecture" enabled, but most probably stopped working since they made some internal reorganization or something similar.

The fix is fairly straight-forward - I checked what most of the other "New Architecture"-compatible modules did and devised a similar solution here. I have tested the build with my app and I can confirm that it works as expected once this fix is applied.

**Affected platforms**

- [x] Android
- [ ] iOS

**Test plan/screenshots/videos**

1. Implement this Gradle build change
2. Build on Android with `newArchEnabled=true` set in the `gradle.properties` file.
3. Profit! 🎉 🎉 🎉
