### PR TITLE
Detect react-native-edge-to-edge and bypass setShouldMimicIOSBehavior

### DIFF
--- a/packages/react-native-avoid-softinput/package.json
+++ b/packages/react-native-avoid-softinput/package.json
@@ -55,6 +55,9 @@
     "build-library": "bob build",
     "release-library": "release-it"
   },
+  "dependencies": {
+    "react-native-is-edge-to-edge": "^1.1.6"
+  },
   "devDependencies": {
     "@release-it/conventional-changelog": "8.0.2",
     "@types/react": "18.3.12",

--- a/packages/react-native-avoid-softinput/src/AvoidSoftInput.ts
+++ b/packages/react-native-avoid-softinput/src/AvoidSoftInput.ts
@@ -1,8 +1,11 @@
 import type { EmitterSubscription } from 'react-native';
 import { NativeEventEmitter, Platform } from 'react-native';
+import { controlEdgeToEdgeValues, isEdgeToEdge } from 'react-native-is-edge-to-edge';
 
 import module from './AvoidSoftInputModule';
 import type { SoftInputAppliedOffsetEventData, SoftInputEasing, SoftInputEventData } from './types';
+
+const EDGE_TO_EDGE = isEdgeToEdge();
 
 const eventEmitter = new NativeEventEmitter(Platform.OS !== 'ios' ? undefined : module);
 
@@ -51,7 +54,12 @@ function setShouldMimicIOSBehavior(shouldMimic: boolean) {
     return;
   }
 
-  module.setShouldMimicIOSBehavior(shouldMimic);
+  if (__DEV__) {
+    // Will print "setShouldMimicIOSBehavior value is ignored when using react-native-edge-to-edge"
+    controlEdgeToEdgeValues({ setShouldMimicIOSBehavior: shouldMimic });
+  }
+
+  module.setShouldMimicIOSBehavior(EDGE_TO_EDGE || shouldMimic);
 }
 
 /**

--- a/packages/react-native-avoid-softinput/src/AvoidSoftInput.ts
+++ b/packages/react-native-avoid-softinput/src/AvoidSoftInput.ts
@@ -53,13 +53,12 @@ function setShouldMimicIOSBehavior(shouldMimic: boolean) {
   if (Platform.OS !== 'android') {
     return;
   }
-
   if (__DEV__) {
-    // Will print "setShouldMimicIOSBehavior value is ignored when using react-native-edge-to-edge"
-    controlEdgeToEdgeValues({ setShouldMimicIOSBehavior: shouldMimic });
+    controlEdgeToEdgeValues({ shouldMimic });
   }
-
-  module.setShouldMimicIOSBehavior(EDGE_TO_EDGE || shouldMimic);
+  if (!EDGE_TO_EDGE) {
+    module.setShouldMimicIOSBehavior(shouldMimic);
+  }
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -13100,6 +13100,7 @@ __metadata:
     react: "npm:18.3.1"
     react-native: "npm:0.76.0"
     react-native-builder-bob: "npm:0.30.2"
+    react-native-is-edge-to-edge: "npm:^1.1.6"
     release-it: "npm:17.6.0"
     typescript: "npm:5.0.4"
   peerDependencies:
@@ -13152,6 +13153,16 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/64ab125c539ca8c275f5d305f5e11d366e6098d9e24e3cab25cbfd46a8d618fc3925ea86219972ccc63364e578384bb0120a72562312e596894a04ee0518a363
+  languageName: node
+  linkType: hard
+
+"react-native-is-edge-to-edge@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "react-native-is-edge-to-edge@npm:1.1.6"
+  peerDependencies:
+    react: ">=18.2.0"
+    react-native: ">=0.73.0"
+  checksum: 10/4e07c1e34c01c8d50fd7c1d0460db06f6f0515197405230386a8ffb950cb724b10743af032310d1384df0a90059bfb8992ba2d93344ce86315315f0493feccc2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Description**

This PR brings `react-native-edge-to-edge` detection to `react-native-avoid-softinput`.

The future of Android is [edge-to-edge](https://developer.android.com/about/versions/15/behavior-changes-15#edge-to-edge), and to make the React Native developer experience seamless in this regard, the ecosystem needs to transition from “opaque system bars by default” to “edge-to-edge by default.”

To prevent library authors from implementing their own edge-to-edge solutions—which could interfere with other libraries—and because it’s not possible to reliably detect if edge-to-edge is already enabled on Android, we have collaborated with [Expo](https://expo.dev/) to create a library that handles this functionality and is detectable using a simple helper: [`react-native-is-edge-to-edge`](https://github.com/zoontek/react-native-edge-to-edge/tree/main/react-native-is-edge-to-edge) (250 bytes minified - no gzip).

This approach allows you to bypass certain options and props (in this case, it removes the need to call `setShouldMimicIOSBehavior` entirely, which is dangerous as `setShouldMimicIOSBehavior(false)` currently breaks edge-to-edge).

After digging a bit into your code, I think this is the only required change. `setShouldMimicIOSBehavior` calls `setShouldHandleInsets`, which only call `WindowCompat.setDecorFitsSystemWindows(activity.window, decorFitsSystemWindows)` (doesn't even update a module level variable or else), something already handled by `react-native-edge-to-edge` that call `WindowCompat.setDecorFitsSystemWindows(activity.window, false)` immediately at app start.

This will also print a warning to inform the users that calling this function is not needed anymore in such case:

> shoudMimic value is ignored when using react-native-edge-to-edge

PS: If you want to keep the call, I can update the TS to be:

```ts
function setShouldMimicIOSBehavior(shouldMimic: boolean) {
  if (Platform.OS !== 'android') {
    return;
  }
  if (__DEV__) {
    controlEdgeToEdgeValues({ shouldMimic });
  }

  module.setShouldMimicIOSBehavior(EDGE_TO_EDGE || shouldMimic);
}
```

**Affected platforms**

- [x] Android
- [ ] iOS