### PR TITLE
chore: fix broken npm version when releasing library

### DIFF
--- a/packages/react-native-avoid-softinput/package.json
+++ b/packages/react-native-avoid-softinput/package.json
@@ -77,7 +77,8 @@
       "tagName": "v${version}"
     },
     "npm": {
-      "publish": true
+      "publish": true,
+      "versionArgs": ["--workspaces-update=false"]
     },
     "github": {
       "release": true


### PR DESCRIPTION
Fixes problem with npm not supporting "workspace:" URL when running `npm version` in release workflow