### PR TITLE
fix(oldarch): setIsEnabled -> setEnabled

### DIFF
--- a/packages/react-native-avoid-softinput/android/src/oldarch/java/com/reactnativeavoidsoftinput/AvoidSoftInputViewManager.kt
+++ b/packages/react-native-avoid-softinput/android/src/oldarch/java/com/reactnativeavoidsoftinput/AvoidSoftInputViewManager.kt
@@ -37,12 +37,12 @@ class AvoidSoftInputViewManager : ReactViewManager() {
     }
 
     @ReactProp(name = "easing")
-    fun setEasing(view: AvoidSoftInputView, easing: String) {
+    fun setEasing(view: AvoidSoftInputView, easing: String?) {
         view.setEasing(easing)
     }
 
     @ReactProp(name = "enabled", defaultBoolean = true)
-    fun setIsEnabled(view: AvoidSoftInputView, enabled: Boolean) {
+    fun setEnabled(view: AvoidSoftInputView, enabled: Boolean) {
         view.setIsEnabled(enabled)
     }
 


### PR DESCRIPTION
**Description**

Build fails with the old architecture in RN 0.80

```
e: node_modules/react-native-avoid-softinput/android/src/reactnative77/java/com/reactnativeavoidsoftinput/AvoidSoftInputViewDelegate.kt:16:76 Argument type mismatch: actual type is 'String?', but 'String' was expected.
e: node_modules/react-native-avoid-softinput/android/src/reactnative77/java/com/reactnativeavoidsoftinput/AvoidSoftInputViewDelegate.kt:18:30 Unresolved reference 'setEnabled'.
```

**Affected platforms**

- [x] Android
- [ ] iOS